### PR TITLE
GitHubリポジトリデータの取得・表示

### DIFF
--- a/Sources/Core/Network/APIClient.swift
+++ b/Sources/Core/Network/APIClient.swift
@@ -1,0 +1,33 @@
+//
+//  APIClient.swift
+//
+//
+//  Created by Ryo Yoshitsugu on R 6/04/11.
+//
+
+import Foundation
+
+ package struct APIClient {
+    private let session:URLSession = {
+        let config = URLSessionConfiguration.default
+        return URLSession(configuration: config)
+    }()
+    
+    package func request<Request: BaseRequestProtocol>(with request: Request) async throws -> Request.ResponseType {
+        let result = try await session.data(for: request.buildURLRequest())
+        try validate(data: result.0, response: result.1)
+        return try JSONDecoder().decode(Request.ResponseType.self, from: result.0)
+    }
+    
+    private func validate(data: Data, response: URLResponse) throws {
+        guard let code = (response as? HTTPURLResponse)?.statusCode else {
+            throw APIClientError.connectionError(data)
+        }
+        
+        guard (200..<300).contains(code) else {
+            throw APIClientError.apiError
+        }
+    }
+     
+     package init () {}
+}

--- a/Sources/Core/Network/APIClientError.swift
+++ b/Sources/Core/Network/APIClientError.swift
@@ -1,0 +1,13 @@
+//
+//  APIClientError.swift
+//
+//
+//  Created by Ryo Yoshitsugu on R 6/04/11.
+//
+
+import Foundation
+
+enum APIClientError: Error {
+    case connectionError(Data)
+    case apiError
+}

--- a/Sources/Core/Network/BaseRequestProtocol.swift
+++ b/Sources/Core/Network/BaseRequestProtocol.swift
@@ -1,0 +1,44 @@
+//
+//  BaseRequestProtocol.swift
+//
+//
+//  Created by Ryo Yoshitsugu on R 6/04/11.
+//
+
+import Foundation
+
+package protocol BaseRequestProtocol {
+    associatedtype ResponseType: Decodable
+    
+    var baseURL: URL { get }
+    var httpMethod: HTTPMethod { get }
+    var path: String { get }
+    var body: String { get }
+    var queryItem: [URLQueryItem] { get }
+    
+    func buildURLRequest() -> URLRequest
+}
+
+extension BaseRequestProtocol {
+    package func buildURLRequest() -> URLRequest {
+        var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: true)
+        urlComponents?.path = path
+        
+        switch httpMethod {
+        case .get:
+            urlComponents?.queryItems = queryItem
+        default:
+            fatalError()
+        }
+        
+        guard let url = urlComponents?.url else {
+            fatalError()
+        }
+        
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = httpMethod.rawValue
+        urlRequest.httpBody = body.data(using: .utf8)
+        
+        return urlRequest
+    }
+}

--- a/Sources/Core/Network/HTTPMethod.swift
+++ b/Sources/Core/Network/HTTPMethod.swift
@@ -1,8 +1,20 @@
 //
-//  File.swift
-//  
+//  HTTPMethod.swift
+//
 //
 //  Created by Ryo Yoshitsugu on R 6/04/11.
 //
 
 import Foundation
+
+package enum HTTPMethod: String {
+    case connect = "CONNECT"
+    case delete = "DELETE"
+    case get = "GET"
+    case head = "HEAD"
+    case options = "OPTIONS"
+    case patch = "PATCH"
+    case post = "POST"
+    case put = "PUT"
+    case trace = "TRACE"
+}

--- a/Sources/Core/Network/HTTPMethod.swift
+++ b/Sources/Core/Network/HTTPMethod.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Ryo Yoshitsugu on R 6/04/11.
+//
+
+import Foundation

--- a/Sources/Data/GitHub/Models/Repository.swift
+++ b/Sources/Data/GitHub/Models/Repository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-package struct Repository: Codable {
+package struct Repository: Codable, Identifiable {
     private enum CodingKeys: String, CodingKey {
         case id
         case name

--- a/Sources/Data/GitHub/Models/SearchResponse.swift
+++ b/Sources/Data/GitHub/Models/SearchResponse.swift
@@ -1,0 +1,19 @@
+//
+//  SearchResponse.swift
+//
+//
+//  Created by Ryo Yoshitsugu on R 6/04/18.
+//
+
+import Foundation
+
+struct SearchResponse<Item: Decodable>: Decodable {
+    
+    private enum CodingKeys: String, CodingKey {
+        case totalCount = "total_count"
+        case items
+    }
+    
+    let totalCount: Int
+    let items: [Item]
+}

--- a/Sources/Data/GitHub/Repositories/RepoRepository.swift
+++ b/Sources/Data/GitHub/Repositories/RepoRepository.swift
@@ -1,0 +1,47 @@
+//
+//  RepoRepository.swift
+//
+//
+//  Created by Ryo Yoshitsugu on R 6/04/12.
+//
+
+import Foundation
+import NetworkCore
+
+package protocol RepoRepository {
+    func searchRepository(keyword: String) async throws -> [Repository]
+}
+
+package final class RepoDefaultRepository: RepoRepository {
+    package static let shared = RepoDefaultRepository()
+    
+    private let apiClient: APIClient
+    
+    package init(apiClient: APIClient = APIClient()) {
+        self.apiClient = APIClient()
+    }
+    
+    package func searchRepository(keyword: String) async throws -> [Repository] {
+        let request = RepositoryRequest(keyword: keyword)
+        let response = try await apiClient.request(with: request)
+        return response.items
+    }
+}
+
+private struct RepositoryRequest: BaseRequestProtocol {
+    typealias ResponseType = SearchResponse<Repository>
+    
+    var baseURL: URL = URL(string: "https://api.github.com")!
+    var httpMethod: HTTPMethod = .get
+    var path: String = "/search/repositories"
+    var body: String = ""
+    var keyword: String
+    
+    init(keyword: String) {
+        self.keyword = keyword
+    }
+    
+    var queryItem: [URLQueryItem] {
+        [URLQueryItem(name: "q", value: self.keyword)]
+    }
+}

--- a/Sources/Features/Home/HomeView.swift
+++ b/Sources/Features/Home/HomeView.swift
@@ -10,10 +10,15 @@ import SwiftUI
 package struct HomeView: View {
     @StateObject var viewModel = HomeViewModel()
     package var body: some View {
-        RepositoryListView()
+        RepositoryListView(repositories: viewModel.uiState.repositories)
             .searchable(text: .init(get: { viewModel.uiState.searchText }, set: { newValue in
                 viewModel.changeSearchText(newValue)
             }))
+            .onSubmit(of: .search) {
+                Task {
+                    try await viewModel.searchRepositories()
+                }
+            }
     }
     
     package init() {}

--- a/Sources/Features/Home/HomeViewModel.swift
+++ b/Sources/Features/Home/HomeViewModel.swift
@@ -11,24 +11,22 @@ import Foundation
 struct RepositoryUIState {
     var repositories: [Repository] = []
     var searchText: String = ""
-    
-    var filteredRepositories: [Repository] {
-        repositories.filter {
-            searchText.isEmpty
-            || $0.name.contains(searchText)
-        }
-    }
 }
 
 @MainActor
 final class HomeViewModel: ObservableObject {
     @Published private(set) var uiState: RepositoryUIState = RepositoryUIState()
+    private let repository: RepoRepository
     
-    func search() {
-        //TODO: Repositoryデータの取得をする関数の呼び出し
+    init(repository: some RepoRepository = RepoDefaultRepository()) {
+        self.repository = repository
     }
     
     func changeSearchText(_ searchText: String) {
         uiState.searchText = searchText
+    }
+    
+    func searchRepositories() async throws {
+        uiState.repositories = try await self.repository.searchRepository(keyword: uiState.searchText)
     }
 }

--- a/Sources/Features/Home/RepositoryListView.swift
+++ b/Sources/Features/Home/RepositoryListView.swift
@@ -6,11 +6,15 @@
 //
 
 import SwiftUI
+import GitHubData
 
 struct RepositoryListView: View {
+    let repositories: [Repository]
     var body: some View {
         List{
-            RepositoryRowView()
+            ForEach(repositories) { repository in
+                RepositoryRowView(repository: repository)
+            }
         }
     }
 }

--- a/Sources/Features/Home/RepositoryRowView.swift
+++ b/Sources/Features/Home/RepositoryRowView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 import GitHubData
 
 struct RepositoryRowView: View {
-    let sampleRepositoryData = Repository.sampleData
+    let repository: Repository
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
                 ownerImage
-                Text(sampleRepositoryData.owner.name)
+                Text(repository.owner.name)
             }
             title
             description
@@ -28,7 +28,7 @@ struct RepositoryRowView: View {
 
 private extension RepositoryRowView {
     var imageURL: URL? {
-        URL(string: sampleRepositoryData.owner.avatarImagePath)
+        URL(string: repository.owner.avatarImagePath)
     }
     
     var ownerImage: some View {
@@ -41,14 +41,14 @@ private extension RepositoryRowView {
     }
     
     var title: some View {
-        Text(sampleRepositoryData.fullName)
+        Text(repository.fullName)
             .bold()
             .font(.system(size: 20))
             .padding(.vertical, 1)
     }
     
     @ViewBuilder var description: some View {
-        if let description = sampleRepositoryData.description {
+        if let description = repository.description {
             Text(description).padding(.bottom, 1)
         }
     }
@@ -56,12 +56,12 @@ private extension RepositoryRowView {
     var starCount: some View {
         HStack(spacing: 0) {
             Image(systemName: "star")
-            Text(String(sampleRepositoryData.starsCount))
+            Text(String(repository.starsCount))
         }
     }
     
     @ViewBuilder var language: some View {
-        if let language = sampleRepositoryData.language {
+        if let language = repository.language {
             HStack(spacing: 0) {
                 Image(systemName: "text.word.spacing")
                 Text(language)


### PR DESCRIPTION
# 概要
<!-- e.g. トレーニング時間、セット数、レストを入力し、データを編集する機能を作成-->
GitHubリポジトリデータの取得・表示
# 目的
<!-- e.g. ユーザーがトレーニングする際に、トレーニング時間、セット数、レストを自身が決めれる仕様にする -->
GitHubAPIからリポジトリデータ取得し、表示する。
# やったこと
<!-- e.g.
- [ ] 編集画面の作成
- [ ] 入力フォームの作成
- [ ] データの紐付け
-->
- [x] APIClientの作成
- [x] Repoリポジトリの作成
- [x] SearchResponseモデルの作成
# 変更内容
<!-- e.g. 変更した部分の画像、動画など -->

https://github.com/tsuguring/github-app/assets/52564598/6cde36a4-5e86-4d46-a1af-3e30598e91ab


# 不安点
<!-- e.g. トレーニング時間の入力フォームについて。Sliderで作成したがPickerの方がいい？ -->

# その他
<!-- e.g. https://...を参考にしました。 -->
参考ページ
- https://zenn.dev/ikeh1024/articles/1b8c0ecc11c99f
- https://qiita.com/yyokii/items/ec216fe62478ebd7be32
- https://github.com/uhooi/Loki