### PR TITLE
画面の状態管理追加

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // Features layer
         .target(
             name: "HomeFeature",
-            dependencies: ["GitHubData"],
+            dependencies: ["GitHubData", "UICore"],
             path: "./Sources/Features/Home"),
         
         //Data layer

--- a/Sources/Core/Network/APIClient.swift
+++ b/Sources/Core/Network/APIClient.swift
@@ -14,14 +14,21 @@ import Foundation
     }()
     
     package func request<Request: BaseRequestProtocol>(with request: Request) async throws -> Request.ResponseType {
-        let result = try await session.data(for: request.buildURLRequest())
+        let result: (Data, URLResponse)
+        
+        do {
+            result = try await session.data(for: request.buildURLRequest())
+        } catch {
+            throw APIClientError.connectionError
+        }
+        
         try validate(data: result.0, response: result.1)
         return try JSONDecoder().decode(Request.ResponseType.self, from: result.0)
     }
     
     private func validate(data: Data, response: URLResponse) throws {
         guard let code = (response as? HTTPURLResponse)?.statusCode else {
-            throw APIClientError.connectionError(data)
+            throw APIClientError.connectionError
         }
         
         guard (200..<300).contains(code) else {

--- a/Sources/Core/Network/APIClientError.swift
+++ b/Sources/Core/Network/APIClientError.swift
@@ -7,7 +7,19 @@
 
 import Foundation
 
-enum APIClientError: Error {
-    case connectionError(Data)
+package enum APIClientError: Error {
+    case connectionError
     case apiError
+    case parseError
+    
+    package var message: String {
+        switch self {
+        case .apiError:
+            return "サーバーからのエラーが発生しました"
+        case .connectionError:
+            return "サーバーと接続できませんでした"
+        case .parseError:
+            return "データの取得に失敗しました"
+        }
+    }
 }

--- a/Sources/Core/UI/Stateful.swift
+++ b/Sources/Core/UI/Stateful.swift
@@ -1,8 +1,15 @@
 //
-//  State.swift
-//  
+//  Stateful.swift
+//
 //
 //  Created by Ryo Yoshitsugu on R 6/04/28.
 //
 
 import Foundation
+
+package enum Stateful<Value> {
+    case idle
+    case loading
+    case success(Value)
+    case failed(Error)
+}

--- a/Sources/Core/UI/Stateful.swift
+++ b/Sources/Core/UI/Stateful.swift
@@ -1,0 +1,8 @@
+//
+//  State.swift
+//  
+//
+//  Created by Ryo Yoshitsugu on R 6/04/28.
+//
+
+import Foundation

--- a/Sources/Features/Home/HomeView.swift
+++ b/Sources/Features/Home/HomeView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 package struct HomeView: View {
     @StateObject var viewModel = HomeViewModel()
     package var body: some View {
-        RepositoryListView(repositories: viewModel.uiState.repositories)
+        RepositoryListView(viewModel: viewModel)
             .searchable(text: .init(get: { viewModel.uiState.searchText }, set: { newValue in
                 viewModel.changeSearchText(newValue)
             }))
             .onSubmit(of: .search) {
                 Task {
-                    try await viewModel.searchRepositories()
+                    await viewModel.searchRepositories()
                 }
             }
     }

--- a/Sources/Features/Home/HomeViewModel.swift
+++ b/Sources/Features/Home/HomeViewModel.swift
@@ -5,28 +5,40 @@
 //  Created by Ryo Yoshitsugu on R 6/04/01.
 //
 
-import GitHubData
 import Foundation
+import GitHubData
+import UICore
 
 struct RepositoryUIState {
-    var repositories: [Repository] = []
+    var repositories: Stateful<[Repository]> = .idle
     var searchText: String = ""
 }
 
 @MainActor
 final class HomeViewModel: ObservableObject {
     @Published private(set) var uiState: RepositoryUIState = RepositoryUIState()
-    private let repository: RepoRepository
+    private let repoRepository: RepoRepository
     
-    init(repository: some RepoRepository = RepoDefaultRepository()) {
-        self.repository = repository
+    init(repoRepository: some RepoRepository = RepoDefaultRepository()) {
+        self.repoRepository = repoRepository
     }
     
     func changeSearchText(_ searchText: String) {
         uiState.searchText = searchText
     }
     
-    func searchRepositories() async throws {
-        uiState.repositories = try await self.repository.searchRepository(keyword: uiState.searchText)
+    func searchRepositories() async {
+        uiState.repositories = .loading
+        Task {
+            do {
+                let repositories = try await self.repoRepository.searchRepository(keyword: uiState.searchText)
+                uiState.repositories = .success(repositories)
+            } catch {
+                if Task.isCancelled {
+                    uiState.repositories = .idle
+                }
+                uiState.repositories = .failed(error)
+            }
+        }
     }
 }

--- a/Sources/Features/Home/RepositoryListView.swift
+++ b/Sources/Features/Home/RepositoryListView.swift
@@ -7,13 +7,73 @@
 
 import SwiftUI
 import GitHubData
+import NetworkCore
 
 struct RepositoryListView: View {
-    let repositories: [Repository]
+    @ObservedObject var viewModel: HomeViewModel
     var body: some View {
+        switch viewModel.uiState.repositories {
+        case .idle:
+            Ready
+        case .loading:
+            Loading
+        case .success(let repositories):
+            RepositoryList(repositories)
+        case .failed(let error):
+            Error(error)
+        }
+    }
+}
+
+private extension RepositoryListView {
+    var Ready: some View {
+        VStack {
+            Image(systemName: "magnifyingglass")
+                .resizable()
+                .frame(width: 70, height: 70)
+            Text("検索しましょう")
+                .font(.system(size:20))
+                .bold()
+                .padding(.bottom, 10)
+            Text("GitHubのリポジトリを検索できます")
+        }
+        
+    }
+    var Loading: some View {
+        VStack {
+            ProgressView()
+            Text("検索中...")
+        }
+    }
+    
+    func RepositoryList(_ repositories: [Repository]) -> some View {
         List{
             ForEach(repositories) { repository in
                 RepositoryRowView(repository: repository)
+            }
+        }
+    }
+    
+    func Error(_ error: Error) -> some View {
+        VStack {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .resizable()
+                .frame(width: 70, height: 70)
+            Text("リポジトリが取得できませんでした")
+                .font(.system(size:20))
+                .bold()
+                .padding(.bottom, 10)
+            if let fetchError = error as? APIClientError {
+                switch fetchError {
+                case .apiError:
+                    Text(fetchError.message)
+                case .connectionError:
+                    Text(fetchError.message)
+                case .parseError:
+                    Text(fetchError.message)
+                }
+            } else {
+                Text(error.localizedDescription)
             }
         }
     }


### PR DESCRIPTION
# 概要
<!-- e.g. トレーニング時間、セット数、レストを入力し、データを編集する機能を作成-->
画面の状態管理を追加する
# 目的
<!-- e.g. ユーザーがトレーニングする際に、トレーニング時間、セット数、レストを自身が決めれる仕様にする -->
アイドル状態、通信成功、失敗、通信中の各画面を正しく表示する
# やったこと
<!-- e.g.
- [ ] 編集画面の作成
- [ ] 入力フォームの作成
- [ ] データの紐付け
-->
- [x] 画面状態を表すStatefulの作成
- [x] ViewModelのripositoriesデータにStatefulを準拠
- [x] 各画面(アイドル状態、通信成功、失敗、通信中)の作成
# 変更内容
<!-- e.g. 変更した部分の画像、動画など -->

| アイドル状態 | 通信成功 | 通信中 | 通信失敗 |
| ------------- | ------------- | ------------- | ------------- |
| <img width = 200 src="https://github.com/tsuguring/github-app/assets/52564598/f77d4c27-5fc5-415a-8e1f-8ac107c542e0"> | <img width = 200 src="https://github.com/tsuguring/github-app/assets/52564598/c0a5bda4-e6a0-48b7-87ee-54fe40951f62"> | <img width = 200 src="https://github.com/tsuguring/github-app/assets/52564598/ecc2027b-e297-4a4a-a453-6d45fa11f0e0"> | <img width = 200 src="https://github.com/tsuguring/github-app/assets/52564598/598ad889-bd22-4abd-84f7-257860b0d929"> |


# 不安点
<!-- e.g. トレーニング時間の入力フォームについて。Sliderで作成したがPickerの方がいい？ -->

# その他
<!-- e.g. https://...を参考にしました。 -->