### PR TITLE
リポジトリ詳細画面の作成

### DIFF
--- a/Sources/Features/Home/RepositoryDetailView.swift
+++ b/Sources/Features/Home/RepositoryDetailView.swift
@@ -1,0 +1,25 @@
+//
+//  RepositoryDetailView.swift
+//
+//
+//  Created by Ryo Yoshitsugu on R 6/06/10.
+//
+
+import SwiftUI
+import WebKit
+
+struct RepositoryDetailView: UIViewRepresentable {
+    typealias UIViewType = WKWebView
+    let repositoryUrl: String
+    
+    func makeUIView(context: Context) -> UIViewType {
+        return WKWebView()
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        if let url = URL(string: repositoryUrl) {
+            let request = URLRequest(url: url)
+            uiView.load(request)
+        }
+    }
+}

--- a/Sources/Features/Home/RepositoryListView.swift
+++ b/Sources/Features/Home/RepositoryListView.swift
@@ -49,7 +49,11 @@ private extension RepositoryListView {
     func RepositoryList(_ repositories: [Repository]) -> some View {
         List {
             ForEach(repositories) { repository in
-                RepositoryRowView(repository: repository)
+                NavigationLink {
+                    RepositoryDetailView(repositoryUrl: repository.htmlPath)
+                } label: {
+                    RepositoryRowView(repository: repository)
+                }
             }
             
             if viewModel.uiState.canLoadNextPage {


### PR DESCRIPTION
# 概要
<!-- e.g. トレーニング時間、セット数、レストを入力し、データを編集する機能を作成-->
リポジトリ詳細画面の作成
# 目的
<!-- e.g. ユーザーがトレーニングする際に、トレーニング時間、セット数、レストを自身が決めれる仕様にする -->
リスト表示されたリポジトリをタップすると、リポジトリの詳細画面として、リポジトリurlのwebviewが表示される
# やったこと
<!-- e.g.
- [ ] 編集画面の作成
- [ ] 入力フォームの作成
- [ ] データの紐付け
-->
- [x] リポジトリ詳細画面をwebkitを用いて作成
- [x] NavigationLinkを用いてリポジトリをタップすると詳細画面に遷移
# 変更内容
<!-- e.g. 変更した部分の画像、動画など -->


https://github.com/tsuguring/github-app/assets/52564598/facacc06-c8a1-4562-83a1-a221608c7396



# 不安点
<!-- e.g. トレーニング時間の入力フォームについて。Sliderで作成したがPickerの方がいい？ -->

# その他
<!-- e.g. https://...を参考にしました。 -->
